### PR TITLE
Renamed Id property to Identifier as Id is a reserved keyword in Azure Table

### DIFF
--- a/src/BaGet.Azure/Table/PackageEntity.cs
+++ b/src/BaGet.Azure/Table/PackageEntity.cs
@@ -15,7 +15,7 @@ namespace BaGet.Azure
         {
         }
 
-        public string Id { get; set; }
+        public string Identifier { get; set; }
         public string NormalizedVersion { get; set; }
         public string OriginalVersion { get; set; }
         public string Authors { get; set; }

--- a/src/BaGet.Azure/Table/TableOperationBuilder.cs
+++ b/src/BaGet.Azure/Table/TableOperationBuilder.cs
@@ -22,7 +22,7 @@ namespace BaGet.Azure
                 PartitionKey = package.Id.ToLowerInvariant(),
                 RowKey = normalizedVersion.ToLowerInvariant(),
 
-                Id = package.Id,
+                Identifier = package.Id,
                 NormalizedVersion = normalizedVersion,
                 OriginalVersion = version.ToFullString(),
                 Authors = JsonConvert.SerializeObject(package.Authors),

--- a/src/BaGet.Azure/Table/TablePackageService.cs
+++ b/src/BaGet.Azure/Table/TablePackageService.cs
@@ -221,7 +221,7 @@ namespace BaGet.Azure
 
             return new Package
             {
-                Id = entity.Id,
+                Id = entity.Identifier,
                 NormalizedVersionString = entity.NormalizedVersion,
                 OriginalVersionString = entity.OriginalVersion,
 

--- a/src/BaGet.Azure/Table/TableSearchService.cs
+++ b/src/BaGet.Azure/Table/TableSearchService.cs
@@ -201,7 +201,7 @@ namespace BaGet.Azure
         private string ToAutocompleteResult(IReadOnlyList<PackageEntity> packages)
         {
             // TODO: This should find the latest version and return its package Id.
-            return packages.Last().Id;
+            return packages.Last().Identifier;
         }
 
         private SearchResult ToSearchResult(IReadOnlyList<PackageEntity> packages)
@@ -218,7 +218,7 @@ namespace BaGet.Azure
                 totalDownloads += package.Downloads;
                 versions.Add(new SearchResultVersion
                 {
-                    RegistrationLeafUrl = _url.GetRegistrationLeafUrl(package.Id, version),
+                    RegistrationLeafUrl = _url.GetRegistrationLeafUrl(package.Identifier, version),
                     Version = package.NormalizedVersion,
                     Downloads = package.Downloads,
                 });
@@ -231,19 +231,19 @@ namespace BaGet.Azure
             }
 
             var iconUrl = latest.HasEmbeddedIcon
-                ? _url.GetPackageIconDownloadUrl(latest.Id, latestVersion)
+                ? _url.GetPackageIconDownloadUrl(latest.Identifier, latestVersion)
                 : latest.IconUrl;
 
             return new SearchResult
             {
-                PackageId = latest.Id,
+                PackageId = latest.Identifier,
                 Version = latest.NormalizedVersion,
                 Description = latest.Description,
                 Authors = JsonConvert.DeserializeObject<string[]>(latest.Authors),
                 IconUrl = iconUrl,
                 LicenseUrl = latest.LicenseUrl,
                 ProjectUrl = latest.ProjectUrl,
-                RegistrationIndexUrl = _url.GetRegistrationIndexUrl(latest.Id),
+                RegistrationIndexUrl = _url.GetRegistrationIndexUrl(latest.Identifier),
                 Summary = latest.Summary,
                 Tags = JsonConvert.DeserializeObject<string[]>(latest.Tags),
                 Title = latest.Title,


### PR DESCRIPTION
Renamed 'Id' property to 'Identifier' for AzureTable implementation
Screenshot shows this working now

Addresses https://github.com/loic-sharma/BaGet/issues/668
